### PR TITLE
UserとPostに対しバリデーションを適応

### DIFF
--- a/controller/post_controller.go
+++ b/controller/post_controller.go
@@ -58,7 +58,7 @@ func (pc *postController) CreatePost(c echo.Context) error {
 	post.AuthorID = uint(userId.(float64))
 	postRes, err := pc.pu.CreatePost(post)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, err.Error())
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	return c.JSON(http.StatusCreated, postRes)
 }

--- a/controller/user_controller.go
+++ b/controller/user_controller.go
@@ -26,23 +26,23 @@ func NewUserController(uu usecase.IUserUsecase) IUserController {
 func (uc *userController) SignUp(c echo.Context) error {
 	user := model.User{}
 	if err := c.Bind(&user); err != nil {
-		return c.JSON(http.StatusBadRequest,err.Error())
+		return c.JSON(http.StatusBadRequest, err.Error())
 	}
-	userRes , err := uc.uu.SingUp(user)
+	userRes, err := uc.uu.SingUp(user)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,err.Error())
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
-	return c.JSON(http.StatusCreated,userRes)
+	return c.JSON(http.StatusCreated, userRes)
 }
 
-func (uc *userController) LogIn(c echo.Context) error{
+func (uc *userController) LogIn(c echo.Context) error {
 	user := model.User{}
 	if err := c.Bind(&user); err != nil {
-		return c.JSON(http.StatusBadRequest,err.Error())
+		return c.JSON(http.StatusBadRequest, err.Error())
 	}
 	tokenString, err := uc.uu.Login(user)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError,err.Error())
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	cookie := new(http.Cookie)
 	cookie.Name = "token"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module backend
 go 1.22.2
 
 require (
+	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo-jwt/v4 v4.1.0
@@ -13,6 +14,7 @@ require (
 )
 
 require (
+	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
+github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
@@ -34,6 +38,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
@@ -56,6 +61,7 @@ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
 golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -6,14 +6,17 @@ import (
 	"backend/repository"
 	"backend/router"
 	"backend/usecase"
+	"backend/validator"
 )
 
 func main() {
 	db := db.NewDB()
+	userValidator := validator.NewUserValidator()
+	postValidator := validator.NewPostValidator()
 	userRepository := repository.NewUserRepository(db)
 	postRepository := repository.NewPostRepository(db)
-	userUsecase := usecase.NewUserUsecase(userRepository)
-	postUsecase := usecase.NewPostUsecase(postRepository)
+	userUsecase := usecase.NewUserUsecase(userRepository, userValidator)
+	postUsecase := usecase.NewPostUsecase(postRepository, postValidator)
 	userController := controller.NewUserController(userUsecase)
 	postController := controller.NewTaskController(postUsecase)
 	e := router.NewRouter(userController, postController)

--- a/usecase/post_usecase.go
+++ b/usecase/post_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"backend/model"
 	"backend/repository"
+	"backend/validator"
 )
 
 type IPostUsecase interface {
@@ -14,10 +15,11 @@ type IPostUsecase interface {
 
 type postUsecase struct {
 	pr repository.IPostRepository
+	pv validator.IPostValidator
 }
 
-func NewPostUsecase(pr repository.IPostRepository) IPostUsecase {
-	return &postUsecase{pr}
+func NewPostUsecase(pr repository.IPostRepository, pv validator.IPostValidator) IPostUsecase {
+	return &postUsecase{pr, pv}
 }
 
 func (pu *postUsecase) GetAllPosts(author_id uint) ([]model.PostResponse, error) {
@@ -57,6 +59,10 @@ func (pu *postUsecase) GetPostByID(planId uint) ([]model.PostResponse, error) {
 }
 
 func (pu *postUsecase) CreatePost(post *model.Post) (model.PostResponse, error) {
+	if err := pu.pv.PostValidate(*post); err != nil {
+		return model.PostResponse{}, err
+	}
+
 	if err := pu.pr.CreatePost(post); err != nil {
 		return model.PostResponse{}, err
 	}

--- a/usecase/user_usecase.go
+++ b/usecase/user_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"backend/model"
 	"backend/repository"
+	"backend/validator"
 	"os"
 	"time"
 
@@ -17,13 +18,17 @@ type IUserUsecase interface {
 
 type userUsecase struct {
 	ur repository.IUserRepository
+	uv validator.IUserValidator
 }
 
-func NewUserUsecase(ur repository.IUserRepository) IUserUsecase {
-	return &userUsecase{ur}
+func NewUserUsecase(ur repository.IUserRepository, uv validator.IUserValidator) IUserUsecase {
+	return &userUsecase{ur, uv}
 }
 
 func (uu *userUsecase) SingUp(user model.User) (model.UserResponse, error) {
+	if err := uu.uv.UserValidate(user); err != nil {
+		return model.UserResponse{}, err
+	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(user.Password), 10)
 	if err != nil {
@@ -41,6 +46,9 @@ func (uu *userUsecase) SingUp(user model.User) (model.UserResponse, error) {
 }
 
 func (uu *userUsecase) Login(user model.User) (string, error) {
+	if err := uu.uv.UserValidate(user); err != nil {
+		return "", err
+	}
 
 	storedUser := model.User{}
 	if err := uu.ur.GetUserByEmail(&storedUser, user.Email); err != nil {

--- a/validator/post_validator.go
+++ b/validator/post_validator.go
@@ -1,0 +1,27 @@
+package validator
+
+import (
+	"backend/model"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+type IPostValidator interface {
+	PostValidate(post model.Post) error
+}
+
+type PostValidator struct{}
+
+func NewPostValidator() IPostValidator {
+	return &PostValidator{}
+}
+
+func (pv *PostValidator) PostValidate(post model.Post) error {
+	return validation.ValidateStruct(&post,
+		validation.Field(
+			&post.Content,
+			validation.Required.Error("Content is required"),
+			validation.Length(1, 15).Error("limited max 15 characters"),
+		),
+	)
+}

--- a/validator/user_validator.go
+++ b/validator/user_validator.go
@@ -1,0 +1,34 @@
+package validator
+
+import (
+	"backend/model"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+type IUserValidator interface {
+	UserValidate(user model.User) error
+}
+
+type UserValidator struct{}
+
+func NewUserValidator() IUserValidator {
+	return &UserValidator{}
+}
+
+func (uv *UserValidator) UserValidate(user model.User) error {
+	return validation.ValidateStruct(&user,
+		validation.Field(
+			&user.Email,
+			validation.Required.Error("Email is required"),
+			validation.Length(1, 30).Error("limited max 30 characters"),
+			is.Email.Error("Email is not valid"),
+		),
+		validation.Field(
+			&user.Password,
+			validation.Required.Error("Password is required"),
+			validation.Length(6, 30).Error("limited min 6 max 30 characters"),
+		),
+	)
+}


### PR DESCRIPTION
### 実装意図
- #7 のPRでPostに関するAPIを作成したが、不適切な値でAPIを呼び出されるとエラーになってしまうため、バリデーションを適応させることにした。

### 実装内容
- `ozzo-validation`を使用してバリデーションを実装
- userについて
  - Emailが空の時、メールアドレスが30字以上の時、正しいメールアドレスの形でないときにメッセージを返す
  - Passwordが空の時と6~30字の制限を守らないときにエラーを返す
- postに関して
  - 内容が空の時、1~15字の制限を守らないときにエラーを返す

### その他
特になし。