### PR TITLE
CORSの設定とCSRFを取得するエンドポイントを作成

### DIFF
--- a/controller/user_controller.go
+++ b/controller/user_controller.go
@@ -14,6 +14,7 @@ type IUserController interface {
 	SignUp(c echo.Context) error
 	LogIn(c echo.Context) error
 	Logout(c echo.Context) error
+	CsrfToken(c echo.Context) error
 }
 type userController struct {
 	uu usecase.IUserUsecase
@@ -69,4 +70,11 @@ func (uc *userController) Logout(c echo.Context) error {
 	cookie.SameSite = http.SameSiteNoneMode
 	c.SetCookie(cookie)
 	return c.NoContent(http.StatusOK)
+}
+
+func (uc *userController) CsrfToken(c echo.Context) error {
+	token := c.Get("csrf").(string)
+	return c.JSON(http.StatusOK, echo.Map{
+		"csrf_token": token,
+	})
 }

--- a/router/router.go
+++ b/router/router.go
@@ -32,6 +32,7 @@ func NewRouter(uc controller.IUserController, pc controller.IPostController) *ec
 	e.POST("/signup", uc.SignUp)
 	e.POST("/login", uc.LogIn)
 	e.POST("/logout", uc.Logout)
+	e.GET("/csrf", uc.CsrfToken)
 	p := e.Group("/posts")
 	// middlewareを追加
 	p.Use(echojwt.WithConfig(echojwt.Config{

--- a/router/router.go
+++ b/router/router.go
@@ -2,14 +2,33 @@ package router
 
 import (
 	"backend/controller"
+	"net/http"
 	"os"
 
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
 func NewRouter(uc controller.IUserController, pc controller.IPostController) *echo.Echo {
 	e := echo.New()
+
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"http://localhost:3000", os.Getenv("FE_URL")},
+		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept,
+			echo.HeaderAccessControlAllowHeaders, echo.HeaderXCSRFToken},
+		AllowMethods:     []string{"GET", "POST", "DELETE", "PUT"},
+		AllowCredentials: true,
+	}))
+	e.Use(middleware.CSRFWithConfig(middleware.CSRFConfig{
+		CookiePath:     "/",
+		CookieDomain:   os.Getenv("API_DOMAIN"),
+		CookieHTTPOnly: true,
+		// CookieSameSite: http.SameSiteNoneMode,
+		CookieSameSite: http.SameSiteDefaultMode, //postmanでのテストのため
+		CookieMaxAge:   60,
+	}))
+
 	e.POST("/signup", uc.SignUp)
 	e.POST("/login", uc.LogIn)
 	e.POST("/logout", uc.Logout)

--- a/router/router.go
+++ b/router/router.go
@@ -13,8 +13,18 @@ import (
 func NewRouter(uc controller.IUserController, pc controller.IPostController) *echo.Echo {
 	e := echo.New()
 
+	// 環境に応じて許可するオリジンを切り替える
+	var allowedOrigins []string
+	if os.Getenv("GO_ENV") == "dev" {
+		// 開発環境
+		allowedOrigins = []string{"http://localhost:3000", os.Getenv("FE_URL")}
+	} else {
+		// 本番環境
+		allowedOrigins = []string{os.Getenv("FE_URL")}
+	}
+
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins: []string{"http://localhost:3000", os.Getenv("FE_URL")},
+		AllowOrigins: allowedOrigins,
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept,
 			echo.HeaderAccessControlAllowHeaders, echo.HeaderXCSRFToken},
 		AllowMethods:     []string{"GET", "POST", "DELETE", "PUT"},
@@ -26,7 +36,7 @@ func NewRouter(uc controller.IUserController, pc controller.IPostController) *ec
 		CookieHTTPOnly: true,
 		// CookieSameSite: http.SameSiteNoneMode,
 		CookieSameSite: http.SameSiteDefaultMode, //postmanでのテストのため
-		CookieMaxAge:   60,
+		// CookieMaxAge:   60,
 	}))
 
 	e.POST("/signup", uc.SignUp)


### PR DESCRIPTION
### 実装意図
- クロスオリジン間の通信を行うためCORSの設定をしようとした。
- またCSRFの対策として、CSRF-Tokenを取得しセキュリティー面向上させようとした。

### 実装内容
- `router.go`でCORSとCSRFのmiddlewareを設定した。許可するオリジンや許可するメソッドを指定。またCookieのパスやドメインも指定。
- `/csrf`というエンドポイントを作成し、csrf-tokenを取得しそれをheaderとして送信することでメソッドを許可している。

### その他
- 開発環境ではPostmanでAPIの動作確認をしているため、CookieSameSiteを`SameSiteDefaultMode`としている。`SameSiteNoneMode`にするとsecure属性がtrueになってしまうためである。
- また`CookieMaxAge`を60sをコメントアウトしているが、デフォルトで24時間に設定されている。本番環境ではコメントアウトを解除してcsrf-tokenの再発行を頻繁にするように設定。