### PR TITLE
認証方法にGoogleでのOAuth認証を追加

### DIFF
--- a/auth/google_config.go
+++ b/auth/google_config.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"os"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+type GoogleAuthConfig interface {
+	GetConfig() *oauth2.Config
+}
+
+type googleAuthConfig struct {
+	config *oauth2.Config
+}
+
+func NewGoogleAuthConfig() GoogleAuthConfig {
+	config := &oauth2.Config{
+		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+		RedirectURL:  os.Getenv("GOOGLE_REDIRECT_URL"),
+		Scopes: []string{
+			"https://www.googleapis.com/auth/userinfo.email",
+			"https://www.googleapis.com/auth/userinfo.profile",
+		},
+		Endpoint: google.Endpoint,
+	}
+
+	return &googleAuthConfig{config: config}
+}
+
+func (g *googleAuthConfig) GetConfig() *oauth2.Config {
+	return g.config
+}

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ require (
 	github.com/labstack/echo-jwt/v4 v4.1.0
 	github.com/labstack/echo/v4 v4.12.0
 	golang.org/x/crypto v0.22.0
+	golang.org/x/oauth2 v0.24.0
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.11
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,6 +11,8 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
@@ -50,6 +54,8 @@ golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
 golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
+golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
+golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"backend/auth"
 	"backend/controller"
 	"backend/db"
 	"backend/repository"
@@ -11,13 +12,14 @@ import (
 
 func main() {
 	db := db.NewDB()
+	googleAuthConfig := auth.NewGoogleAuthConfig()
 	userValidator := validator.NewUserValidator()
 	postValidator := validator.NewPostValidator()
 	planValidator := validator.NewPlanValidator()
 	userRepository := repository.NewUserRepository(db)
 	postRepository := repository.NewPostRepository(db)
 	planRepository := repository.NewPlanRepository(db)
-	userUsecase := usecase.NewUserUsecase(userRepository, userValidator)
+	userUsecase := usecase.NewUserUsecase(userRepository, userValidator, googleAuthConfig)
 	postUsecase := usecase.NewPostUsecase(postRepository, postValidator)
 	planUsecase := usecase.NewPlanUsecase(planRepository, planValidator)
 	userController := controller.NewUserController(userUsecase)

--- a/model/user.go
+++ b/model/user.go
@@ -1,14 +1,14 @@
 package model
 
 type User struct {
-	ID           uint    `json:"id" gorm:"primaryKey"`
-	Email        string  `json:"email" gorm:"unique"`
-	Password     string  `json:"password"`
-	Name         *string `json:"name"`
-	UniversityID *uint   `json:"university_id"`
-	FacultyID    *uint   `json:"faculty_id"`
-	DepartmentID *uint   `json:"department_id"`
-	Grade        *int    `json:"grade"`
+	ID           uint   `json:"id" gorm:"primaryKey"`
+	Email        string `json:"email" gorm:"unique"`
+	Password     string `json:"password"`
+	Name         string `json:"name"`
+	UniversityID *uint  `json:"university_id"`
+	FacultyID    *uint  `json:"faculty_id"`
+	DepartmentID *uint  `json:"department_id"`
+	Grade        *uint  `json:"grade"`
 
 	University *University    `json:"university" gorm:"foreignKey:UniversityID"`
 	Faculty    *Faculty       `json:"faculty" gorm:"foreignKey:FacultyID"`
@@ -24,4 +24,9 @@ type UserResponse struct {
 	University *University `json:"university"`
 	Faculty    *Faculty    `json:"faculty"`
 	Department *Department `json:"department"`
+}
+
+type GoogleUserInfo struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
 }

--- a/repository/user_repository.go
+++ b/repository/user_repository.go
@@ -9,15 +9,17 @@ import (
 type IUserRepository interface {
 	GetUserByEmail(user *model.User, email string) error
 	CreateUser(user *model.User) error
+	ExistsUserByEmail(email string) (bool, error)
 }
 
 type userRepository struct {
-	db *gorm.DB	
+	db *gorm.DB
 }
 
 func NewUserRepository(db *gorm.DB) IUserRepository {
 	return &userRepository{db}
 }
+
 // dbの中からemailが一致するユーザーを取得
 func (ur *userRepository) GetUserByEmail(user *model.User, email string) error {
 	if err := ur.db.Where("email=?", email).First(user).Error; err != nil {
@@ -25,10 +27,19 @@ func (ur *userRepository) GetUserByEmail(user *model.User, email string) error {
 	}
 	return nil
 }
+
 // ユーザーを作成
 func (ur *userRepository) CreateUser(user *model.User) error {
 	if err := ur.db.Create(user).Error; err != nil {
 		return err
 	}
 	return nil
+}
+
+func (ur *userRepository) ExistsUserByEmail(email string) (bool, error) {
+	var count int64
+	if err := ur.db.Model(&model.User{}).Where("email = ?", email).Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }

--- a/router/router.go
+++ b/router/router.go
@@ -43,7 +43,7 @@ func NewRouter(uc controller.IUserController, pc controller.IPostController, plc
 		CookieHTTPOnly: true,
 		// CookieSameSite: http.SameSiteNoneMode,
 		CookieSameSite: http.SameSiteDefaultMode, //postmanでのテストのため
-		// CookieMaxAge:   60,
+		// CookieMaxAge: 86400,
 	}))
 	// グループ化
 	p := e.Group("/posts")
@@ -54,6 +54,8 @@ func NewRouter(uc controller.IUserController, pc controller.IPostController, plc
 	e.POST("/login", uc.LogIn)
 	e.POST("/logout", uc.Logout)
 	e.GET("/csrf", uc.CsrfToken)
+	e.GET("/auth/google/login", uc.GoogleLogin)
+	e.GET("/auth/google/callback", uc.GoogleCallback)
 
 	// postに関するエンドポイント
 	p.Use(jwtMiddleware())

--- a/usecase/user_usecase.go
+++ b/usecase/user_usecase.go
@@ -7,6 +7,13 @@ import (
 	"os"
 	"time"
 
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"backend/auth"
+
 	"github.com/golang-jwt/jwt/v4"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -14,15 +21,23 @@ import (
 type IUserUsecase interface {
 	SingUp(user model.User) (model.UserResponse, error)
 	Login(user model.User) (string, error)
+	GetGoogleAuthURL() string
+	GoogleCallback(code string) (string, error)
 }
 
 type userUsecase struct {
-	ur repository.IUserRepository
-	uv validator.IUserValidator
+	ur               repository.IUserRepository
+	uv               validator.IUserValidator
+	googleAuthConfig auth.GoogleAuthConfig
 }
 
-func NewUserUsecase(ur repository.IUserRepository, uv validator.IUserValidator) IUserUsecase {
-	return &userUsecase{ur, uv}
+func NewUserUsecase(
+	ur repository.IUserRepository, uv validator.IUserValidator, gac auth.GoogleAuthConfig) IUserUsecase {
+	return &userUsecase{
+		ur:               ur,
+		uv:               uv,
+		googleAuthConfig: gac,
+	}
 }
 
 func (uu *userUsecase) SingUp(user model.User) (model.UserResponse, error) {
@@ -67,4 +82,61 @@ func (uu *userUsecase) Login(user model.User) (string, error) {
 		return "", err
 	}
 	return tokenString, nil
+}
+
+func (uu *userUsecase) GetGoogleAuthURL() string {
+	return uu.googleAuthConfig.GetConfig().AuthCodeURL("state")
+}
+
+func (uu *userUsecase) GoogleCallback(code string) (string, error) {
+	config := uu.googleAuthConfig.GetConfig()
+	// Googleからトークンを取得
+	token, err := config.Exchange(context.Background(), code)
+	if err != nil {
+		return "", err
+	}
+
+	// ユーザー情報を取得
+	res, err := http.Get("https://www.googleapis.com/oauth2/v2/userinfo?access_token=" + token.AccessToken)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	userInfo := model.GoogleUserInfo{}
+	if err := json.NewDecoder(res.Body).Decode(&userInfo); err != nil {
+		return "", err
+	}
+
+	// DBからユーザーを検索
+	user := model.User{}
+	exists, err := uu.ur.ExistsUserByEmail(userInfo.Email)
+	if err != nil {
+		return "", fmt.Errorf("failed to check user existence: %w", err)
+	}
+
+	if !exists {
+		// ユーザーが存在しない場合は新規作成
+		newUser := model.User{
+			Email: userInfo.Email,
+			Name:  userInfo.Name,
+		}
+		if err := uu.ur.CreateUser(&newUser); err != nil {
+			return "", fmt.Errorf("failed to create new user: %w", err)
+		}
+		user = newUser
+	} else {
+		// ユーザーが存在する場合は取得
+		if err := uu.ur.GetUserByEmail(&user, userInfo.Email); err != nil {
+			return "", fmt.Errorf("failed to get existing user: %w", err)
+		}
+	}
+
+	// JWTトークンを生成
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user_id": user.ID,
+		"exp":     time.Now().Add(time.Hour * 12).Unix(),
+	})
+
+	return jwtToken.SignedString([]byte(os.Getenv("SECRET")))
 }


### PR DESCRIPTION
### 実装意図
- 現状の認証方法としてメールアドレスを用いた認証方法を実現していたが、ユーザー認証の手軽さを実現するため GoogleアカウントでのOAuth認証を追加したかった。

### 実装内容
*usecase層に関連するもの*

- `oauth2`と`oauth2/google`のパッケージを使用して、`google_config.go`に Google認証の設定を記述
  - client_idなどを環境変数を読み込んでメールアドレスとプロフィール内容へのアクセスを許可
- 次にusecase層の`GetGoogleAuthURL`関数で認証ページのURLを生成
- `GoogleCallback`関数では認証後のコールバック関数の役割を担っている
  - ユーザー情報を取得し、新規ユーザーの場合は登録、既存ユーザーの場合は情報を取得する
  - 最後にJWTトークンを生成して返す
  - またユーザーの新規登録時は先ほどメールアドレスとプロフィール情報から取得したものをユーザー情報のemailとnameにセットするように設定

*controller層に関連するもの*
- クライアントから渡された認証コード（code）を受け取る。
- 認証コードを用いてサーバー側でGoogleユーザー情報を処理し、JWTトークンを生成。
- JWTトークンをクライアントに安全に送信する（HTTPクッキーに設定）。
- フロントエンドの指定URLへリダイレクト

*repository層に関連するもの*
- 指定されたメールアドレスを持つユーザーがデータベースに存在するか確認するメソッドを実装。
- 返り値をbool値で設定しており、カウントされたレコードが1件以上なら存在する、0件なら存在しないことを返す。


### その他
*参考にした記事など*
- https://zenn.dev/sgtkuc1118/articles/693e2930f8151c
- https://qiita.com/yukiaprogramming/items/095ec818963a1e42823b