### PR TITLE
`Course`に対する取得、作成、更新、削除のメソッドを作成

### DIFF
--- a/controller/course_controller.go
+++ b/controller/course_controller.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"backend/model"
+	"backend/usecase"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+type ICourseController interface {
+	GetAllCourses(c echo.Context) error
+	CreateCourse(c echo.Context) error
+	UpdateCourse(c echo.Context) error
+	DeleteCourseByID(c echo.Context) error
+}
+
+type courseController struct {
+	cu usecase.ICourseUsecase
+}
+
+func NewCourseController(cu usecase.ICourseUsecase) ICourseController {
+	return &courseController{cu}
+}
+
+func (cc *courseController) GetAllCourses(c echo.Context) error {
+	id := c.Param("courseId")
+	planId, _ := strconv.Atoi(id)
+	postRes, err := cc.cu.GetAllCourses(uint(planId))
+	if err != nil {
+		return c.JSON(500, err.Error())
+	}
+	return c.JSON(200, postRes)
+}
+
+func (cc *courseController) CreateCourse(c echo.Context) error {
+	course := &[]model.Course{}
+	if err := c.Bind(course); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+	postRes, err := cc.cu.CreateCourse(course)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, postRes)
+}
+
+func (cc *courseController) UpdateCourse(c echo.Context) error {
+	id := c.Param("courseId")
+	courseId, _ := strconv.Atoi(id)
+
+	course := &model.Course{}
+	if err := c.Bind(course); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+
+	postRes, err := cc.cu.UpdateCourse(course, courseId)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, postRes)
+}
+
+func (cc *courseController) DeleteCourseByID(c echo.Context) error {
+	id := c.Param("courseId")
+	courseId, _ := strconv.Atoi(id)
+
+	err := cc.cu.DeleteCourseByID(uint(courseId))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, "Deleted")
+}

--- a/controller/course_controller.go
+++ b/controller/course_controller.go
@@ -11,7 +11,7 @@ import (
 
 type ICourseController interface {
 	GetAllCourses(c echo.Context) error
-	CreateCourse(c echo.Context) error
+	CreateCourses(c echo.Context) error
 	UpdateCourse(c echo.Context) error
 	DeleteCourseByID(c echo.Context) error
 }
@@ -34,16 +34,18 @@ func (cc *courseController) GetAllCourses(c echo.Context) error {
 	return c.JSON(200, postRes)
 }
 
-func (cc *courseController) CreateCourse(c echo.Context) error {
-	course := &[]model.Course{}
-	if err := c.Bind(course); err != nil {
+func (cc *courseController) CreateCourses(c echo.Context) error {
+	var courses []model.Course
+	if err := c.Bind(&courses); err != nil {
 		return c.JSON(http.StatusBadRequest, err.Error())
 	}
-	postRes, err := cc.cu.CreateCourse(course)
+
+	createdCourses, err := cc.cu.CreateCourses(courses)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, err.Error())
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
-	return c.JSON(http.StatusOK, postRes)
+
+	return c.JSON(http.StatusCreated, createdCourses)
 }
 
 func (cc *courseController) UpdateCourse(c echo.Context) error {

--- a/controller/course_controller.go
+++ b/controller/course_controller.go
@@ -72,5 +72,5 @@ func (cc *courseController) DeleteCourseByID(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, "Deleted")
+	return c.JSON(http.StatusOK, map[string]string{"success": "Course deleted successfully"})
 }

--- a/main.go
+++ b/main.go
@@ -12,19 +12,33 @@ import (
 
 func main() {
 	db := db.NewDB()
+	// auth
 	googleAuthConfig := auth.NewGoogleAuthConfig()
+
+	// validation
 	userValidator := validator.NewUserValidator()
 	postValidator := validator.NewPostValidator()
 	planValidator := validator.NewPlanValidator()
+
+	// repository
 	userRepository := repository.NewUserRepository(db)
 	postRepository := repository.NewPostRepository(db)
 	planRepository := repository.NewPlanRepository(db)
+	courseRepository := repository.NewCourseRepository(db)
+
+	// usecase
 	userUsecase := usecase.NewUserUsecase(userRepository, userValidator, googleAuthConfig)
 	postUsecase := usecase.NewPostUsecase(postRepository, postValidator)
 	planUsecase := usecase.NewPlanUsecase(planRepository, planValidator)
+	courseUsecase := usecase.NewCourseUsecase(courseRepository)
+
+	// controller
 	userController := controller.NewUserController(userUsecase)
 	postController := controller.NewTaskController(postUsecase)
 	planController := controller.NewPlanController(planUsecase)
-	e := router.NewRouter(userController, postController, planController)
+	courseController := controller.NewCourseController(courseUsecase)
+
+	// router
+	e := router.NewRouter(userController, postController, planController, courseController)
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/repository/course_repository.go
+++ b/repository/course_repository.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"backend/model"
+
+	"gorm.io/gorm"
+)
+
+type ICourseRepository interface {
+	GetAllCourses(courses *[]model.Course, planId uint) error
+	CreateCourse(course *[]model.Course) error
+	UpdateCourse(course *model.Course, courseId int) error
+	DeleteCourseByID(courseId uint) error
+}
+
+type courseRepository struct {
+	db *gorm.DB
+}
+
+func NewCourseRepository(db *gorm.DB) ICourseRepository {
+	return &courseRepository{db}
+}
+
+func (cr *courseRepository) GetAllCourses(courses *[]model.Course, planId uint) error {
+	if err := cr.db.Where("plan_id = ?", planId).Find(courses).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cr *courseRepository) CreateCourse(course *[]model.Course) error {
+	for _, c := range *course {
+		if err := cr.db.Create(&c).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cr *courseRepository) UpdateCourse(course *model.Course, courseId int) error {
+	if err := cr.db.Model(&model.Course{}).Where("id = ?", courseId).Updates(course).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cr *courseRepository) DeleteCourseByID(courseId uint) error {
+	if err := cr.db.Where("id = ?", courseId).Delete(&model.Course{}).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/repository/course_repository.go
+++ b/repository/course_repository.go
@@ -8,7 +8,7 @@ import (
 
 type ICourseRepository interface {
 	GetAllCourses(courses *[]model.Course, planId uint) error
-	CreateCourse(course *[]model.Course) error
+	CreateCourses(courses *[]model.Course) error
 	UpdateCourse(course *model.Course, courseId int) error
 	DeleteCourseByID(courseId uint) error
 }
@@ -28,11 +28,9 @@ func (cr *courseRepository) GetAllCourses(courses *[]model.Course, planId uint) 
 	return nil
 }
 
-func (cr *courseRepository) CreateCourse(course *[]model.Course) error {
-	for _, c := range *course {
-		if err := cr.db.Create(&c).Error; err != nil {
-			return err
-		}
+func (cr *courseRepository) CreateCourses(courses *[]model.Course) error {
+	if err := cr.db.Create(courses).Error; err != nil {
+		return err
 	}
 	return nil
 }

--- a/repository/course_repository.go
+++ b/repository/course_repository.go
@@ -43,8 +43,12 @@ func (cr *courseRepository) UpdateCourse(course *model.Course, courseId int) err
 }
 
 func (cr *courseRepository) DeleteCourseByID(courseId uint) error {
-	if err := cr.db.Where("id = ?", courseId).Delete(&model.Course{}).Error; err != nil {
-		return err
+	result := cr.db.Where("id = ?", courseId).Delete(&model.Course{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected < 1 {
+		return gorm.ErrRecordNotFound
 	}
 	return nil
 }

--- a/router/router.go
+++ b/router/router.go
@@ -80,7 +80,7 @@ func NewRouter(
 	// courseに関するエンドポイント
 	c.Use(jwtMiddleware())
 	c.GET("/:courseId", cc.GetAllCourses)
-	c.POST("", cc.CreateCourse)
+	c.POST("", cc.CreateCourses)
 	c.PUT("/:courseId", cc.UpdateCourse)
 	c.DELETE("/:courseId", cc.DeleteCourseByID)
 

--- a/router/router.go
+++ b/router/router.go
@@ -17,7 +17,11 @@ func jwtMiddleware() echo.MiddlewareFunc {
 	})
 }
 
-func NewRouter(uc controller.IUserController, pc controller.IPostController, plc controller.IPlanController) *echo.Echo {
+func NewRouter(
+	uc controller.IUserController,
+	pc controller.IPostController,
+	plc controller.IPlanController,
+	cc controller.ICourseController) *echo.Echo {
 	e := echo.New()
 
 	// 環境に応じて許可するオリジンを切り替える
@@ -48,6 +52,7 @@ func NewRouter(uc controller.IUserController, pc controller.IPostController, plc
 	// グループ化
 	p := e.Group("/posts")
 	pl := e.Group("/plans")
+	c := e.Group("/courses")
 
 	// 認証に関するエンドポイント
 	e.POST("/signup", uc.SignUp)
@@ -71,6 +76,13 @@ func NewRouter(uc controller.IUserController, pc controller.IPostController, plc
 	pl.POST("", plc.CreatePlan)
 	pl.PUT("/:planId", plc.UpdatePlan)
 	pl.DELETE("/:planId", plc.DeletePlanByID)
+
+	// courseに関するエンドポイント
+	c.Use(jwtMiddleware())
+	c.GET("/:planId", cc.GetAllCourses)
+	c.POST("", cc.CreateCourse)
+	c.PUT("/:courseId", cc.UpdateCourse)
+	c.DELETE("/:courseId", cc.DeleteCourseByID)
 
 	return e
 }

--- a/router/router.go
+++ b/router/router.go
@@ -78,7 +78,6 @@ func NewRouter(
 	pl.DELETE("/:planId", plc.DeletePlanByID)
 
 	// courseに関するエンドポイント
-	c.Use(jwtMiddleware())
 	c.GET("/:courseId", cc.GetAllCourses)
 	c.POST("", cc.CreateCourses)
 	c.PUT("/:courseId", cc.UpdateCourse)

--- a/router/router.go
+++ b/router/router.go
@@ -79,7 +79,7 @@ func NewRouter(
 
 	// courseに関するエンドポイント
 	c.Use(jwtMiddleware())
-	c.GET("/:planId", cc.GetAllCourses)
+	c.GET("/:courseId", cc.GetAllCourses)
 	c.POST("", cc.CreateCourse)
 	c.PUT("/:courseId", cc.UpdateCourse)
 	c.DELETE("/:courseId", cc.DeleteCourseByID)

--- a/usecase/course_usecase.go
+++ b/usecase/course_usecase.go
@@ -1,0 +1,59 @@
+package usecase
+
+import (
+	"backend/model"
+	"backend/repository"
+)
+
+type ICourseUsecase interface {
+	GetAllCourses(planId uint) ([]model.CourseResponse, error)
+	CreateCourse(course *[]model.Course) (model.CourseResponse, error)
+	UpdateCourse(course *model.Course, courseId int) (model.CourseResponse, error)
+	DeleteCourseByID(courseId uint) error
+}
+
+type courseUsecase struct {
+	cr repository.ICourseRepository
+}
+
+func NewCourseUsecase(cr repository.ICourseRepository) ICourseUsecase {
+	return &courseUsecase{cr}
+}
+
+func (cu *courseUsecase) GetAllCourses(planId uint) ([]model.CourseResponse, error) {
+	courses := []model.Course{}
+	if err := cu.cr.GetAllCourses(&courses, planId); err != nil {
+		return nil, err
+	}
+	resCourses := []model.CourseResponse{}
+	for _, v := range courses {
+		c := model.CourseResponse{
+			ID:      v.ID,
+			Name:    v.Name,
+			Content: v.Content,
+		}
+		resCourses = append(resCourses, c)
+	}
+	return resCourses, nil
+}
+
+func (cu *courseUsecase) CreateCourse(course *[]model.Course) (model.CourseResponse, error) {
+	if err := cu.cr.CreateCourse(course); err != nil {
+		return model.CourseResponse{}, err
+	}
+	return model.CourseResponse{}, nil
+}
+
+func (cu *courseUsecase) UpdateCourse(course *model.Course, courseId int) (model.CourseResponse, error) {
+	if err := cu.cr.UpdateCourse(course, courseId); err != nil {
+		return model.CourseResponse{}, err
+	}
+	return model.CourseResponse{}, nil
+}
+
+func (cu *courseUsecase) DeleteCourseByID(courseId uint) error {
+	if err := cu.cr.DeleteCourseByID(courseId); err != nil {
+		return err
+	}
+	return nil
+}

--- a/usecase/course_usecase.go
+++ b/usecase/course_usecase.go
@@ -7,7 +7,7 @@ import (
 
 type ICourseUsecase interface {
 	GetAllCourses(planId uint) ([]model.CourseResponse, error)
-	CreateCourse(course *[]model.Course) (model.CourseResponse, error)
+	CreateCourses(courses []model.Course) ([]model.CourseResponse, error)
 	UpdateCourse(course *model.Course, courseId int) (model.CourseResponse, error)
 	DeleteCourseByID(courseId uint) error
 }
@@ -37,11 +37,20 @@ func (cu *courseUsecase) GetAllCourses(planId uint) ([]model.CourseResponse, err
 	return resCourses, nil
 }
 
-func (cu *courseUsecase) CreateCourse(course *[]model.Course) (model.CourseResponse, error) {
-	if err := cu.cr.CreateCourse(course); err != nil {
-		return model.CourseResponse{}, err
+func (cu *courseUsecase) CreateCourses(courses []model.Course) ([]model.CourseResponse, error) {
+	if err := cu.cr.CreateCourses(&courses); err != nil {
+		return nil, err
 	}
-	return model.CourseResponse{}, nil
+	resCourses := []model.CourseResponse{}
+	for _, v := range courses {
+		c := model.CourseResponse{
+			ID:      v.ID,
+			Name:    v.Name,
+			Content: v.Content,
+		}
+		resCourses = append(resCourses, c)
+	}
+	return resCourses, nil
 }
 
 func (cu *courseUsecase) UpdateCourse(course *model.Course, courseId int) (model.CourseResponse, error) {

--- a/usecase/course_usecase.go
+++ b/usecase/course_usecase.go
@@ -57,7 +57,11 @@ func (cu *courseUsecase) UpdateCourse(course *model.Course, courseId int) (model
 	if err := cu.cr.UpdateCourse(course, courseId); err != nil {
 		return model.CourseResponse{}, err
 	}
-	return model.CourseResponse{}, nil
+	return model.CourseResponse{
+		ID:      uint(courseId),
+		Name:    course.Name,
+		Content: course.Content,
+	}, nil
 }
 
 func (cu *courseUsecase) DeleteCourseByID(courseId uint) error {


### PR DESCRIPTION
### 実装意図
- #10 に引き続き、`Course`に関連するAPIを作成するために必要なメソッドを作成したかった。
- 基本的な構成は以前と同様に層ごとに責務を分けて実装する。

### 実装内容
 *repository層*
- `GetAllCourses`ではplanに関連付けされているcourseを取得するために`plan_id`を使用して検索
- `DeleteCourseByID`では`id`をもとに削除するレコードを検索し、RowsAffectedでレコードがない時エラーを返す処理を追加

*usecase層*
- `GetAllCourses`と`CreateCourses`は返り値が配列なのでforで回して適切に値が帰るように実装。

*controller層*
- 特に特徴的なことはしておらず、適切にstatusを返すように実装。


### その他
特になし。実装内容的にも基本的なことが多かったのでつまらずに実装することができた。