### PR TITLE
履修プランのお気に入り登録に関連するAPIを実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "echojwt",
+        "gorm",
         "kameiryohei",
         "Usecase"
     ]

--- a/router/router.go
+++ b/router/router.go
@@ -44,6 +44,8 @@ func NewRouter(
 	pl.POST("", plc.CreatePlan)
 	pl.PUT("/:planId", plc.UpdatePlan)
 	pl.DELETE("/:planId", plc.DeletePlanByID)
+	pl.POST("/:planId/favorite", plc.ToggleFavoritePlan)
+	pl.GET("/:planId/favorite/count", plc.GetFavoriteCount)
 
 	// courseに関するエンドポイント
 	c.GET("/:courseId", cc.GetAllCourses)

--- a/usecase/plan_usecase.go
+++ b/usecase/plan_usecase.go
@@ -4,14 +4,17 @@ import (
 	"backend/model"
 	"backend/repository"
 	"backend/validator"
+	"errors"
 )
 
 type IPlanUsecase interface {
 	GetAllPlans(offset int, limit int) ([]model.PlanResponse, error)
 	GetPlanByID(planId uint) (model.PlanDetailResponse, error)
 	CreatePlan(plan *model.Plan) (model.PlanBaseResponse, error)
-	UpdatePlan(plan *model.Plan, planId int) (model.PlanUpdateResponse, error)
+	UpdatePlan(plan *model.Plan, planId uint) (model.PlanUpdateResponse, error) // planId の型を uint に変更
 	DeletePlanByID(planId uint) error
+	ToggleFavoritePlan(userId, planId uint) error
+	GetFavoriteCount(planId uint) (int64, error)
 }
 
 type planUsecase struct {
@@ -20,43 +23,44 @@ type planUsecase struct {
 }
 
 func NewPlanUsecase(pr repository.IPlanRepository, plv validator.IPlanValidator) IPlanUsecase {
-	return &planUsecase{pr, plv}
+	return &planUsecase{pr: pr, plv: plv}
 }
 
 func (pu *planUsecase) GetAllPlans(offset int, limit int) ([]model.PlanResponse, error) {
-	plans := []model.Plan{}
+	var plans []model.Plan
 	if err := pu.pr.GetAllPlans(&plans, offset, limit); err != nil {
 		return nil, err
 	}
-	resPlans := []model.PlanResponse{}
-	for _, v := range plans {
-		p := model.PlanResponse{
-			ID:        v.ID,
-			Title:     v.Title,
-			Content:   v.Content,
-			UserID:    v.UserID,
-			CreatedAt: v.CreatedAt,
-			UpdatedAt: v.UpdatedAt,
+
+	// スライスの容量を事前に確保
+	resPlans := make([]model.PlanResponse, 0, len(plans))
+	for _, plan := range plans {
+		resPlans = append(resPlans, model.PlanResponse{
+			ID:        plan.ID,
+			Title:     plan.Title,
+			Content:   plan.Content,
+			UserID:    plan.UserID,
+			CreatedAt: plan.CreatedAt,
+			UpdatedAt: plan.UpdatedAt,
 			UserResponse: model.UserResponse{
-				ID:         v.User.ID,
-				Email:      v.User.Email,
-				University: v.User.University,
-				Faculty:    v.User.Faculty,
-				Department: v.User.Department,
+				ID:         plan.User.ID,
+				Email:      plan.User.Email,
+				University: plan.User.University,
+				Faculty:    plan.User.Faculty,
+				Department: plan.User.Department,
 			},
-		}
-		resPlans = append(resPlans, p)
+		})
 	}
 	return resPlans, nil
 }
 
 func (pu *planUsecase) GetPlanByID(planId uint) (model.PlanDetailResponse, error) {
-	plan := model.Plan{}
+	var plan model.Plan
 	if err := pu.pr.GetPlanByID(&plan, planId); err != nil {
 		return model.PlanDetailResponse{}, err
 	}
 
-	courses := []model.CourseResponse{}
+	courses := make([]model.CourseResponse, 0, len(plan.Courses))
 	for _, course := range plan.Courses {
 		courses = append(courses, model.CourseResponse{
 			ID:      course.ID,
@@ -64,7 +68,8 @@ func (pu *planUsecase) GetPlanByID(planId uint) (model.PlanDetailResponse, error
 			Content: course.Content,
 		})
 	}
-	posts := []model.PostResponse{}
+
+	posts := make([]model.PostResponse, 0, len(plan.Posts))
 	for _, post := range plan.Posts {
 		posts = append(posts, model.PostResponse{
 			ID:        post.ID,
@@ -72,7 +77,8 @@ func (pu *planUsecase) GetPlanByID(planId uint) (model.PlanDetailResponse, error
 			CreatedAt: post.CreatedAt,
 		})
 	}
-	favorites := []model.FavoritePlanResponse{}
+
+	favorites := make([]model.FavoritePlanResponse, 0, len(plan.Favorites))
 	for _, favorite := range plan.Favorites {
 		favorites = append(favorites, model.FavoritePlanResponse{
 			ID:     favorite.ID,
@@ -103,10 +109,13 @@ func (pu *planUsecase) GetPlanByID(planId uint) (model.PlanDetailResponse, error
 }
 
 func (pu *planUsecase) CreatePlan(plan *model.Plan) (model.PlanBaseResponse, error) {
+	// nilチェック（必要に応じて）
+	if plan == nil {
+		return model.PlanBaseResponse{}, errors.New("plan is nil")
+	}
 	if err := pu.plv.PlanValidate(*plan); err != nil {
 		return model.PlanBaseResponse{}, err
 	}
-
 	if err := pu.pr.CreatePlan(plan); err != nil {
 		return model.PlanBaseResponse{}, err
 	}
@@ -121,11 +130,14 @@ func (pu *planUsecase) CreatePlan(plan *model.Plan) (model.PlanBaseResponse, err
 	return resPlan, nil
 }
 
-func (pu *planUsecase) UpdatePlan(plan *model.Plan, planId int) (model.PlanUpdateResponse, error) {
+func (pu *planUsecase) UpdatePlan(plan *model.Plan, planId uint) (model.PlanUpdateResponse, error) {
+	// nilチェック
+	if plan == nil {
+		return model.PlanUpdateResponse{}, errors.New("plan is nil")
+	}
 	if err := pu.plv.PlanValidate(*plan); err != nil {
 		return model.PlanUpdateResponse{}, err
 	}
-
 	if err := pu.pr.UpdatePlan(plan, planId); err != nil {
 		return model.PlanUpdateResponse{}, err
 	}
@@ -140,8 +152,13 @@ func (pu *planUsecase) UpdatePlan(plan *model.Plan, planId int) (model.PlanUpdat
 }
 
 func (pu *planUsecase) DeletePlanByID(planId uint) error {
-	if err := pu.pr.DeletePlanByID(planId); err != nil {
-		return err
-	}
-	return nil
+	return pu.pr.DeletePlanByID(planId)
+}
+
+func (pu *planUsecase) ToggleFavoritePlan(userId, planId uint) error {
+	return pu.pr.ToggleFavoritePlan(userId, planId)
+}
+
+func (pu *planUsecase) GetFavoriteCount(planId uint) (int64, error) {
+	return pu.pr.GetFavoriteCount(planId)
 }


### PR DESCRIPTION
### 実装意図
- planに対してお気に入り登録をする機能を作成したかったため、本PRでは次の二つのapiを作成した
  - 新しくお気に入り登録をする処理、すでにしている場合は削除する処理
  - 指定したplanのお気に入り数をカウントして返却する処理

### 実装内容
*repository*
1. `UpdatePlan`関数の`planId`の型を`int`から`uint`に変更し統一
2.  新しいメソッドを追加:
  - `ToggleFavoritePlan`: ユーザーのお気に入りのプランを追加または削除するメソッド
  - `GetFavoriteCount`: 指定されたプランのお気に入り数を取得するメソッド

3. コードのリファクタリング:
- 重複していたエラーハンドリング部分を簡素化
- `NewPlanRepository`関数の返り値を構造体のフィールド名を指定する形に変更

*usecase*

1. メソッドの変更:
   - `UpdatePlan`関数の`planId`の型を`int`から`uint`に変更に統一
   - 新しいメソッドを追加:
     - `ToggleFavoritePlan`: ユーザーのお気に入りのプランを追加または削除するメソッド
     - `GetFavoriteCount`: 指定されたプランのお気に入り数を取得するメソッド

2. コードのリファクタリング:
   - 重複していたエラーハンドリング部分を簡素化
   - スライスの容量を事前に確保する形に変更


*contoroller*
1. メソッドの変更:
- 同様にUpdatePlan関数のplanIdの型をintからuintに変更

2. 新しいメソッドを追加:
- ToggleFavoritePlanとGetFavoriteCountという名の二つのメソッドを作成。内容は他の層と同様

### その他
- repository層は基本的にDB操作を担う層であり、ビジネスロジックはusecase層が担うと認識している。その観点で考えると今回のreposirotyの以下の記述は不完全ではないかと考えた。
```
if errors.Is(result.Error, gorm.ErrRecordNotFound) {
		// お気に入りが存在しない場合は新規作成
		newFavorite := model.FavoritePlan{
			UserID: userId,
			PlanID: planId,
		}
		return pr.db.Create(&newFavorite).Error
	} else if result.Error != nil {
		return result.Error
	}

```
しかし、DB内での存在チェックとそれに応じたINSERT/DELETEという、DB操作の範囲内に収まっていると考えられる。したがって、ビジネスロジックというよりは、データ永続化の実装として適切であると判断できるため今回の実装を用いた。他社のコードレビュー機会があれば評価をいただきたいと考えた。
