### PR TITLE
feat: Planに対するコメント機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work.sum
 
 # env file
 .env
+.cursor

--- a/controller/comment_controller.go
+++ b/controller/comment_controller.go
@@ -1,0 +1,94 @@
+package controller
+
+import (
+	"backend/model"
+	"backend/usecase"
+	"net/http"
+	"strconv"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/labstack/echo/v4"
+)
+
+type ICommentController interface {
+	CreateComment(c echo.Context) error
+	GetCommentsByPlanID(c echo.Context) error
+	GetMyComments(c echo.Context) error
+	DeleteComment(c echo.Context) error
+}
+
+type commentController struct {
+	cu usecase.ICommentUsecase
+}
+
+func NewCommentController(cu usecase.ICommentUsecase) ICommentController {
+	return &commentController{cu: cu}
+}
+
+func (cc *commentController) CreateComment(c echo.Context) error {
+	comment := &model.Comment{}
+	if err := c.Bind(comment); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+
+	// JWTトークンがある場合はユーザーIDを設定
+	if user, ok := c.Get("user").(*jwt.Token); ok {
+		claims := user.Claims.(jwt.MapClaims)
+		userId := uint(claims["user_id"].(float64))
+		comment.UserID = &userId
+	}
+
+	res, err := cc.cu.CreateComment(comment)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusCreated, res)
+}
+
+func (cc *commentController) GetCommentsByPlanID(c echo.Context) error {
+	planID, err := strconv.ParseUint(c.Param("planId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid plan ID"})
+	}
+
+	comments, err := cc.cu.GetCommentsByPlanID(uint(planID))
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, comments)
+}
+
+func (cc *commentController) GetMyComments(c echo.Context) error {
+	user := c.Get("user").(*jwt.Token)
+	claims := user.Claims.(jwt.MapClaims)
+	userID := uint(claims["user_id"].(float64))
+
+	comments, err := cc.cu.GetCommentsByUserID(userID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, comments)
+}
+
+func (cc *commentController) DeleteComment(c echo.Context) error {
+	commentID, err := strconv.ParseUint(c.Param("commentId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid comment ID"})
+	}
+
+	var userID *uint
+	if user, ok := c.Get("user").(*jwt.Token); ok {
+		claims := user.Claims.(jwt.MapClaims)
+		id := uint(claims["user_id"].(float64))
+		userID = &id
+	}
+
+	if err := cc.cu.DeleteComment(uint(commentID), userID); err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"message": "Comment deleted successfully"})
+}

--- a/main.go
+++ b/main.go
@@ -25,20 +25,23 @@ func main() {
 	postRepository := repository.NewPostRepository(db)
 	planRepository := repository.NewPlanRepository(db)
 	courseRepository := repository.NewCourseRepository(db)
+	commentRepository := repository.NewCommentRepository(db)
 
 	// usecase
 	userUsecase := usecase.NewUserUsecase(userRepository, userValidator, googleAuthConfig)
 	postUsecase := usecase.NewPostUsecase(postRepository, postValidator)
 	planUsecase := usecase.NewPlanUsecase(planRepository, planValidator)
 	courseUsecase := usecase.NewCourseUsecase(courseRepository)
+	commentUsecase := usecase.NewCommentUsecase(commentRepository)
 
 	// controller
 	userController := controller.NewUserController(userUsecase)
 	postController := controller.NewTaskController(postUsecase)
 	planController := controller.NewPlanController(planUsecase)
 	courseController := controller.NewCourseController(courseUsecase)
+	commentController := controller.NewCommentController(commentUsecase)
 
 	// router
-	e := router.NewRouter(userController, postController, planController, courseController)
+	e := router.NewRouter(userController, postController, planController, courseController, commentController)
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -18,5 +18,7 @@ func main() {
 		&model.Faculty{},
 		&model.FavoritePlan{},
 		&model.Plan{},
-		&model.Post{})
+		&model.Post{},
+		&model.Comment{},
+	)
 }

--- a/model/comment.go
+++ b/model/comment.go
@@ -1,0 +1,22 @@
+package model
+
+import "time"
+
+type Comment struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Content   string    `json:"content"`
+	PlanID    uint      `json:"plan_id"`
+	UserID    *uint     `json:"user_id"` // 認証ユーザーの場合のみ設定
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	User      *User     `json:"user" gorm:"foreignKey:UserID"`
+	Plan      Plan      `json:"plan" gorm:"foreignKey:PlanID"`
+}
+
+type CommentResponse struct {
+	ID        uint      `json:"id"`
+	Content   string    `json:"content"`
+	PlanID    uint      `json:"plan_id"`
+	UserID    *uint     `json:"user_id"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/repository/comment_repository.go
+++ b/repository/comment_repository.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"backend/model"
+
+	"gorm.io/gorm"
+)
+
+type ICommentRepository interface {
+	CreateComment(comment *model.Comment) error
+	GetCommentsByPlanID(planID uint) ([]model.Comment, error)
+	GetCommentsByUserID(userID uint) ([]model.Comment, error)
+	DeleteComment(commentID uint, userID *uint) error
+}
+
+type commentRepository struct {
+	db *gorm.DB
+}
+
+func NewCommentRepository(db *gorm.DB) ICommentRepository {
+	return &commentRepository{db: db}
+}
+
+func (cr *commentRepository) CreateComment(comment *model.Comment) error {
+	return cr.db.Create(comment).Error
+}
+
+func (cr *commentRepository) GetCommentsByPlanID(planID uint) ([]model.Comment, error) {
+	var comments []model.Comment
+	err := cr.db.Preload("User").Where("plan_id = ?", planID).Order("created_at desc").Find(&comments).Error
+	return comments, err
+}
+
+func (cr *commentRepository) GetCommentsByUserID(userID uint) ([]model.Comment, error) {
+	var comments []model.Comment
+	err := cr.db.Preload("Plan").Where("user_id = ?", userID).Order("created_at desc").Find(&comments).Error
+	return comments, err
+}
+
+func (cr *commentRepository) DeleteComment(commentID uint, userID *uint) error {
+	query := cr.db.Where("id = ?", commentID)
+	if userID != nil {
+		query = query.Where("user_id = ?", userID)
+	}
+	result := query.Delete(&model.Comment{})
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return result.Error
+}

--- a/router/router.go
+++ b/router/router.go
@@ -11,7 +11,8 @@ func NewRouter(
 	uc controller.IUserController,
 	pc controller.IPostController,
 	plc controller.IPlanController,
-	cc controller.ICourseController) *echo.Echo {
+	cc controller.ICourseController,
+	ccu controller.ICommentController) *echo.Echo {
 	e := echo.New()
 
 	e.Use(middleware.CorsMiddleware())
@@ -21,6 +22,8 @@ func NewRouter(
 	p := e.Group("/posts")
 	pl := e.Group("/plans")
 	c := e.Group("/courses")
+	comments := e.Group("/comments")
+	authComments := e.Group("/comments")
 
 	// 認証に関するエンドポイント
 	e.POST("/signup", uc.SignUp)
@@ -52,6 +55,16 @@ func NewRouter(
 	c.POST("", cc.CreateCourses)
 	c.PUT("/:courseId", cc.UpdateCourse)
 	c.DELETE("/:courseId", cc.DeleteCourseByID)
+
+	// コメント関連のルート（認証不要）
+	comments.Use(middleware.OptionalJwtMiddleware())
+	comments.POST("", ccu.CreateComment)
+	comments.GET("/plan/:planId", ccu.GetCommentsByPlanID)
+
+	// 認証が必要なコメント関連のルート
+	authComments.Use(middleware.JwtMiddleware())
+	authComments.GET("/me", ccu.GetMyComments)
+	authComments.DELETE("/:commentId", ccu.DeleteComment)
 
 	return e
 }

--- a/usecase/comment_usecase.go
+++ b/usecase/comment_usecase.go
@@ -1,0 +1,81 @@
+package usecase
+
+import (
+	"backend/model"
+	"backend/repository"
+)
+
+type ICommentUsecase interface {
+	CreateComment(comment *model.Comment) (model.CommentResponse, error)
+	GetCommentsByPlanID(planID uint) ([]model.CommentResponse, error)
+	GetCommentsByUserID(userID uint) ([]model.CommentResponse, error)
+	DeleteComment(commentID uint, userID *uint) error
+}
+
+type commentUsecase struct {
+	cr repository.ICommentRepository
+}
+
+func NewCommentUsecase(cr repository.ICommentRepository) ICommentUsecase {
+	return &commentUsecase{cr: cr}
+}
+
+func (cu *commentUsecase) CreateComment(comment *model.Comment) (model.CommentResponse, error) {
+	if err := cu.cr.CreateComment(comment); err != nil {
+		return model.CommentResponse{}, err
+	}
+
+	response := model.CommentResponse{
+		ID:        comment.ID,
+		Content:   comment.Content,
+		PlanID:    comment.PlanID,
+		UserID:    comment.UserID,
+		CreatedAt: comment.CreatedAt,
+	}
+
+	return response, nil
+}
+
+func (cu *commentUsecase) GetCommentsByPlanID(planID uint) ([]model.CommentResponse, error) {
+	comments, err := cu.cr.GetCommentsByPlanID(planID)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]model.CommentResponse, len(comments))
+	for i, comment := range comments {
+		responses[i] = model.CommentResponse{
+			ID:        comment.ID,
+			Content:   comment.Content,
+			PlanID:    comment.PlanID,
+			UserID:    comment.UserID,
+			CreatedAt: comment.CreatedAt,
+		}
+	}
+
+	return responses, nil
+}
+
+func (cu *commentUsecase) GetCommentsByUserID(userID uint) ([]model.CommentResponse, error) {
+	comments, err := cu.cr.GetCommentsByUserID(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]model.CommentResponse, len(comments))
+	for i, comment := range comments {
+		responses[i] = model.CommentResponse{
+			ID:        comment.ID,
+			Content:   comment.Content,
+			PlanID:    comment.PlanID,
+			UserID:    comment.UserID,
+			CreatedAt: comment.CreatedAt,
+		}
+	}
+
+	return responses, nil
+}
+
+func (cu *commentUsecase) DeleteComment(commentID uint, userID *uint) error {
+	return cu.cr.DeleteComment(commentID, userID)
+}


### PR DESCRIPTION
## 概要
Planに対するコメント機能の追加

## 詳細
以下の機能を追加しました：

### 新規追加ファイル
- model/comment.go: コメントのモデル定義
- repository/comment_repository.go: コメントのデータベース操作
- controller/comment_controller.go: コメントのエンドポイント制御
- usecase/comment_usecase.go: コメントのビジネスロジック

### 既存ファイルの修正
- main.go: コメント機能の依存関係注入
- middleware/middleware.go: オプショナルJWT認証ミドルウェアの追加
- migrate/migrate.go: コメントテーブルのマイグレーション追加
- router/router.go: コメント関連のエンドポイント追加

### 主な機能
1. コメントの作成（認証・非認証ユーザー両方可能）
2. プランIDに基づくコメント取得
3. 自分のコメント一覧取得（認証ユーザーのみ）
4. コメントの削除（認証ユーザーのみ）

## 参考
- コメントは認証・非認証ユーザー両方が作成可能にすることでユーザーからの気軽なコメントをできるように実現した。
- 認証ユーザーの場合はユーザー情報が紐付けられる
- コメントの削除は作成者のみ可能にすることで不正に削除されることを防いだ

## その他
- Postmanからのリクエストテストを行いすべて正常に動作することを確認した。