### PR TITLE
renderにデプロイするために自動デプロイを作成 

### DIFF
--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,21 @@
+name: Render Deploy
+
+on:
+  push:
+    branches:
+      - main # mainブランチにプッシュされた時のみ実行
+  pull_request:
+    branches:
+      - main # mainブランチへのプルリクエスト時に実行
+
+jobs:
+  deploy:
+    name: Deploy to Render
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ttskch/render-deploy@v1.0.0
+        with:
+          api-key: ${{ secrets.RENDER_API_KEY }}
+          service-id: ${{ secrets.RENDER_SERVICE_ID }}
+          interval: 20 # デプロイステータスのチェック間隔（秒）
+          timeout: 300 # タイムアウトまでの時間（秒）

--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # 大学生の履修登録を簡易化するアプリ「ClassPlanner」(Backend)
 
 ## 概要
+
 大学生の履修登録を簡易化するアプリ「ClassPlanner」のバックエンドリポジトリです。
 
 ## リプレイスのきっかけ
+
 以前**Next.js**を使用してフルスタックなアプリケーションを作成しました。ですが、その際にフロントエンドとバックエンドのコードが混在してしまい、管理が煩雑になってしまいました。そのため、今回はフロントエンドとバックエンドを分離し、バックエンドのリポジトリを新たに作成しました。
-またTypescript以外の言語を学ぶことで将来的な技術選定の際に幅広い選択肢を持つことができると考え、今回は**Go**を使って何かを作成してみようと思いリプレイスを行いました。
+また Typescript 以外の言語を学ぶことで将来的な技術選定の際に幅広い選択肢を持つことができると考え、今回は**Go**を使って何かを作成してみようと思いリプレイスを行いました。
 
 ## 使用技術
-- *Language*
+
+- _Language_
   - **Go**(version 1.22.2)
-- *Framework*
+- _Framework_
   - **Echo**(version 4.12.0)
-- *DB*
+- _DB_
   - **PostgreSQL**(image: postgres:15.1-alpine)
-- *Other*
+- _Other_
   - **GORM**(version 1.25.11)
   - **ozzo-validation**(version 4.3.0)
   - **Docker**
 
 ## ディレクトリ構成
+
 ```
 .
 ├── auth        # 認証関連の処理
@@ -33,14 +37,16 @@
 ├── usecase     # ビジネスロジック
 └── validator   # バリデーション
 ```
+
 ## アーキテクチャと採用理由
+
 - **Clean Architecture**
   - ビジネスロジックとデータベースアクセスを分離することで、ビジネスロジックの変更がデータベースアクセスに影響を与えないようにするため。
 
 ## 処理の流れ
-![backend architecture](https://github.com/user-attachments/assets/c0e3a336-8140-46e6-a9b1-43cdfe9d1fd2)
 
-
+![backend architecture](https://github.com/user-attachments/assets/92be2cf1-a32a-4311-8f8b-474a06a52cbd)
 
 ## その他
+
 - フロントエンドリポジトリ(https://github.com/kameiryohei/Ie-ClassPro)


### PR DESCRIPTION
### 実装意図
このPRではデプロイ先であるrenderに自動デプロイをするためにCI/CDを構築するために作成した。
renderを選んだ理由としてまだ開発初期段階であるため無料枠の中で運用したいと考えたため。将来的にはインフラの知識を得てGoogle CloudのCloud Runなどの実務で使われているクラウドサービスでデプロイしたいと考えている。

### 実装内容
- renderのGithub Actionsを探していたところ以下の記事を見つけこれを使ってみることにした。
- (https://zenn.dev/ttskch/articles/33250dc0a5845c)

### その他
- 現在の段階でうまく動くかわからないため、万が一失敗した場合はrevertして原因を探ることにする。
- (追記)初期段階ではうまくいなかったため原因を調べていたが、Githubのactionsの環境変数に入れるものを間違えていた。具体的にはRENDER_SERVICE_IDにrenderから取得できるhttps~から始めるものを全て入れていたが、厳密にはsrv~を入れる必要があった。修正してdashboardにデプロイができていることが確認できた。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated deployment workflow to Render for updates on the main branch and pull requests.
- **Documentation**
  - Improved README formatting and readability.
  - Updated backend architecture image link and adjusted section emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->